### PR TITLE
test: validate native Merge Gate job check

### DIFF
--- a/.github/actions/publish-gating-check/action.yml
+++ b/.github/actions/publish-gating-check/action.yml
@@ -47,6 +47,13 @@ inputs:
     description: Check-run name (only used when creating a fresh check-run)
     required: false
     default: 'Run Gating Tests'
+  github-token:
+    description: |
+      Token to create/update the check-run with. Use a bot App token so the
+      check-run gets its own check-suite and isn't grouped under an unrelated
+      workflow in the PR checks UI. Falls back to the default GITHUB_TOKEN.
+    required: false
+    default: ''
 
 outputs:
   check-run-id:
@@ -69,6 +76,7 @@ runs:
         CHECK_DETAILS_URL: ${{ inputs['details-url'] }}
         CHECK_NAME: ${{ inputs.name }}
       with:
+        github-token: ${{ inputs.github-token || github.token }}
         script: |
           const output = {
             title: process.env.CHECK_TITLE,

--- a/.github/scripts/src/e2e/verify.ts
+++ b/.github/scripts/src/e2e/verify.ts
@@ -101,7 +101,7 @@ const main = async (): Promise<void> => {
   // 4. Publish "Run Gating Tests" check-run
   let publishedCheckRunId = 0;
   try {
-    publishedCheckRunId = await publishCheckRun(octokit, {
+    publishedCheckRunId = await publishCheckRun(botOctokit, {
       owner,
       repo,
       name: 'Run Gating Tests',
@@ -153,7 +153,7 @@ const main = async (): Promise<void> => {
   if (publishedCheckRunId > 0) {
     try {
       const closed = await closeOrphanedCheckRuns(
-        octokit,
+        botOctokit,
         owner,
         repo,
         prHeadSha,

--- a/.github/workflows/hot-cluster-e2e-pr-gate.yml
+++ b/.github/workflows/hot-cluster-e2e-pr-gate.yml
@@ -84,12 +84,11 @@ jobs:
           persist-credentials: false
           ref: ${{ github.event.repository.default_branch }}
 
-      # This job's own gate already guarantees e2e-hold is present -- the
-      # dispatch job's identical steps only run when it's absent, so between
-      # the two, a push clears the stale label regardless of hold state.
+      # Bot token used for label writes and for publishing the gating check-run
+      # under the bot App's own check-suite (avoids GitHub grouping it under an
+      # unrelated workflow).
       - name: Generate bot token
         id: bot-token
-        if: github.event.action == 'synchronize'
         uses: ./.github/actions/create-bot-token
         with:
           app-id: ${{ secrets.BOT_APP_ID }}
@@ -110,6 +109,7 @@ jobs:
           status: completed
           conclusion: neutral
           title: 'Hot Cluster E2E: held via /hold-e2e'
+          github-token: ${{ steps.bot-token.outputs.token }}
           summary: |
             Required check not satisfied -- hold active. Testing is on hold for this PR.
 

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -197,6 +197,15 @@ jobs:
       # Closes the window where an older failed check would stay "current" while
       # this run is in progress -- verify-gating-tests supersedes it again on
       # completion. Skipped for a bare ad-hoc dispatch or a failed PR context lookup.
+      - name: Generate bot token for gating check
+        id: gating-bot-token
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/create-bot-token
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
       - name: Supersede stale "Run Gating Tests" check for this run
         id: supersede-gating-check
         if: |
@@ -213,6 +222,7 @@ jobs:
           title: Hot Cluster E2E is running
           summary: A fresh Hot Cluster E2E run has started for this commit -- see the "Hot Cluster E2E Progress" check for live status.
           details-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          github-token: ${{ steps.gating-bot-token.outputs.token }}
 
   # should_run gates an untrusted PR dispatch (ad-hoc dispatches always run);
   # run_health_check is ad-hoc-only too, so PR dispatches skip its cost. Folded
@@ -442,6 +452,14 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Generate bot token
+        id: bot-token
+        continue-on-error: true
+        uses: ./.github/actions/create-bot-token
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
       - name: Close prepare's check-run as superseded
         continue-on-error: true
         uses: ./.github/actions/publish-gating-check
@@ -451,3 +469,4 @@ jobs:
           conclusion: neutral
           title: 'Hot Cluster E2E: superseded'
           summary: This run was cancelled -- superseded by a newer Hot Cluster E2E run for this PR. See the newer run for the current result.
+          github-token: ${{ steps.bot-token.outputs.token }}

--- a/.github/workflows/on-main-push.yml
+++ b/.github/workflows/on-main-push.yml
@@ -78,6 +78,14 @@ jobs:
         working-directory: .github/scripts
         run: npx tsx src/merge/stale-mark-check.ts
 
+      - name: Generate bot token
+        id: bot-token
+        if: always()
+        uses: ./.github/actions/create-bot-token
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
       - name: Mark check stale
         if: steps.check.outputs.should_mark == 'true'
         uses: ./.github/actions/publish-gating-check
@@ -87,14 +95,7 @@ jobs:
           conclusion: neutral
           title: 'Hot Cluster E2E: stale -- main has advanced since this ran'
           summary: ${{ steps.check.outputs.summary }}
-
-      - name: Generate bot token
-        id: bot-token
-        if: always()
-        uses: ./.github/actions/create-bot-token
-        with:
-          app-id: ${{ secrets.BOT_APP_ID }}
-          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          github-token: ${{ steps.bot-token.outputs.token }}
 
       - name: Clear stale e2e-passed/e2e-failed
         if: always()

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -116,6 +116,15 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Generate bot token
+        id: bot-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          permission-checks: write
+
       - name: Publish held marker
         uses: ./.github/actions/publish-gating-check
         with:
@@ -128,6 +137,7 @@ jobs:
 
             No new run will be dispatched automatically while this hold is active.
             Comment `/retest-e2e` to lift the hold and get a fresh result.
+          github-token: ${{ steps.bot-token.outputs.token }}
 
   # Post-hold report (after everything above completes)
   report-hold:


### PR DESCRIPTION
## Summary
- Validate Merge Gate now uses native job check instead of Checks API
- Should show as "Auto Merge / Evaluate Merge Eligibility" with red X and step summary

## Test plan
- [ ] Merge Gate shows as native clickable Actions check
- [ ] Step summary shows eligibility details inline
- [ ] No more "Needs Rebase / Merge Gate" grouping


Made with [Cursor](https://cursor.com)